### PR TITLE
Remove unnecessary import 

### DIFF
--- a/electrochemistry.ttl
+++ b/electrochemistry.ttl
@@ -12,8 +12,7 @@
 
 <http://emmo.info/electrochemistry/electrochemistry> rdf:type owl:Ontology ;
                                                       owl:versionIRI <http://emmo.info/electrochemistry/0.4.0/electrochemistry> ;
-                                                      owl:imports <http://emmo.info/electrochemistry/0.4.0/electrochemicalquantities.ttl> ,
-                                                                  <http://emmo.info/emmo/1.0.0-beta4/disciplines/isq_big_map> ;
+                                                      owl:imports <http://emmo.info/electrochemistry/0.4.0/electrochemicalquantities.ttl> ;
                                                       dcterms:abstract """Everything needed to describe fundamental concepts in electrochemistry common to all electrochemical systems.
 
 Released under the Creative Commons license Attribution 4.0 International (CC BY 4.0)."""@en ;
@@ -3178,7 +3177,7 @@ of other configurations are used."""@en ;
                                                        emmo:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25 "https://dbpedia.org/page/Electrolyte"@en ;
                                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "A material in which the mobile species are ions and free movement of electrons is blocked." ;
                                                        emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Electrolyte"@en ;
-                                                       rdfs:comment """1. Conducting medium in which the flow of electric current is accompanied by the movement of ions. 
+                                                       rdfs:comment """1. Conducting medium in which the flow of electric current is accompanied by the movement of ions.
 2. Substance that provides ions on dissolution in a solvent or on melting."""@en ,
                                                                     "A solid electrolyte is a solid material where the predominant charge carriers are ions. For example: NASICON (Na Super Ionic Conductor), which has the general formula Na1+xZr2P3-xSix O12 , 0 < x < 3."@en ,
                                                                     "An ionic liquid is an electrolyte composed of a salt that is liquid below 100 °C. Ionic liquids have found uses in electrochemical analysis, because their unconventional properties include a negligible vapor pressure, a high thermal and electrochemical stability, and exceptional dissolution properties for both organic and inorganic chemical species."@en ,
@@ -3195,7 +3194,7 @@ of other configurations are used."""@en ;
 [ rdf:type owl:Axiom ;
    owl:annotatedSource :electrochemistry_fb0d9eef_92af_4628_8814_e065ca255d59 ;
    owl:annotatedProperty rdfs:comment ;
-   owl:annotatedTarget """1. Conducting medium in which the flow of electric current is accompanied by the movement of ions. 
+   owl:annotatedTarget """1. Conducting medium in which the flow of electric current is accompanied by the movement of ions.
 2. Substance that provides ions on dissolution in a solvent or on melting."""@en ;
    dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
  ] .


### PR DESCRIPTION
Module electrochemistry doesn't need to import isq_bigmap, since it already gets it via electrochemicalquantities.