### PR TITLE
WIP: Correct catalog-file for importing in Protege directly from url

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,10 +24,10 @@ jobs:
 
     - name: Run EMMO Check - electrochemistry
       run: |
-        emmocheck --verbose --check-imported --url-from-catalog \
-          --skip test_namespace \
-          --skip test_quantity_dimension \
-          --configfile=.github/utils/emmocheck_config.yml \
+        emmocheck --verbose --check-imported --url-from-catalog \n
+          --skip test_namespace \n
+          --skip test_quantity_dimension \n
+          --configfile=.github/utils/emmocheck_config.yml \n
           electrochemistry.ttl
 
     - name: Run EMMO Check - electrochemicalquantities

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,10 +24,10 @@ jobs:
 
     - name: Run EMMO Check - electrochemistry
       run: |
-        emmocheck --verbose --check-imported --url-from-catalog 
-          --skip test_namespace 
-          --skip test_quantity_dimension 
-          --configfile=.github/utils/emmocheck_config.yml 
+        emmocheck --verbose --check-imported --url-from-catalog \
+          --skip test_namespace \
+          --skip test_quantity_dimension \
+          --configfile=.github/utils/emmocheck_config.yml \
           electrochemistry.ttl
 
     - name: Run EMMO Check - electrochemicalquantities

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,10 +24,10 @@ jobs:
 
     - name: Run EMMO Check - electrochemistry
       run: |
-        emmocheck --verbose --check-imported --url-from-catalog \n
-          --skip test_namespace \n
-          --skip test_quantity_dimension \n
-          --configfile=.github/utils/emmocheck_config.yml \n
+        emmocheck --verbose --check-imported --url-from-catalog 
+          --skip test_namespace 
+          --skip test_quantity_dimension 
+          --configfile=.github/utils/emmocheck_config.yml 
           electrochemistry.ttl
 
     - name: Run EMMO Check - electrochemicalquantities

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -5,8 +5,8 @@
 	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemistry"             uri="./electrochemistry.ttl"/>
 
 	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities"    uri="./electrochemicalquantities.ttl"/>
-	<uri name="http://emmo.info/emmo/1.0.0-beta"                                     uri="https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl"/>
-        <uri name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map"                   uri="./isq_big_map.ttl"/>
+	<uri name="http://emmo.info/emmo/1.0.0-beta4"                                    uri="https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta4/emmo-inferred.ttl"/>
+        <uri name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map"                   uri="./isq_bigmap.ttl"/>
 	<uri name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap"         uri="./unitsextension_bigmap.ttl"/>
         <uri name="http://emmo.info/material/0.1.0/material"                             uri="./material_bigmap_temp.ttl"/>
     </group>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,18 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="http://emmo.info/material/0.1.0/material" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/material_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/unitsextension_bigmap.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4" uri="https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/reference/1.0.0-beta3" uri="https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta3/emmo-reference-inferred.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/disciplines/isq_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/isq_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/disciplines/units_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/units_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4/disciplines/computerscience_big_map" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/computerscience_bigmap_temp.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities" uri="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/reference/1.0.0-beta3" uri="https://raw.githubusercontent.com/emmo-repo/emmo-repo.github.io/master/versions/1.0.0-beta3/emmo-reference-inferred.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta4" uri="https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl"/>
-    <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-        <uri name="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemistry.ttl" uri="electrochemistry.ttl"/>
-        <uri name="https://raw.githubusercontent.com/emmo-repo/domain-electrochemistry/master/electrochemicalquantities.ttl" uri="electrochemicalquantities.ttl"/>
+<group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
+
+	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemistry"             uri="./electrochemistry.ttl"/>
+
+	<uri name="http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities"    uri="./electrochemicalquantities.ttl"/>
+	<uri name="http://emmo.info/emmo/1.0.0-beta"                                     uri="https://emmo-repo.github.io/versions/1.0.0-beta4/emmo-inferred.ttl"/>
+        <uri name="http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map"                   uri="./isq_big_map.ttl"/>
+	<uri name="http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap"         uri="./unitsextension_bigmap.ttl"/>
+        <uri name="http://emmo.info/material/0.1.0/material"                             uri="./material_bigmap_temp.ttl"/>
     </group>
 </catalog>

--- a/electrochemicalquantities.ttl
+++ b/electrochemicalquantities.ttl
@@ -13,7 +13,7 @@
 <http://emmo.info/electrochemistry/electrochemicalquantities> rdf:type owl:Ontology ;
                                                                owl:versionIRI <http://emmo.info/electrochemistry/0.5.0/electrochemicalquantities.ttl> ;
                                                                owl:imports <http://emmo.info/emmo/1.0.0-beta4> ,
-                                                                           <http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map> ,
+                                                                           <http://emmo.info/emmo/1.0.0-beta4/temp/isq_bigmap> ,
                                                                            <http://emmo.info/emmo/1.0.0-beta4/temp/unitsextension_bigmap> ,
                                                                            <http://emmo.info/material/0.1.0/material> ;
                                                                dcterms:abstract """Everything needed to describe fundamental quantities in electrochemistry common to all electrochemical systems.
@@ -610,7 +610,7 @@ and t* through mathematical models, provided that the long-time potential- deter
                                                                        emmo:EMMO_96f39f77_44dc_491b_8fa7_30d887fe0890 ;
                                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Area of electrode - solution interface."@en ;
                                                        rdfs:comment "A"@en ,
-                                                                    """The geometric area, A_{geom} , is the interfacial area, determined on the assumption that the interface is truly flat (2-dimensional) and calculated using the geometric data of the involved surfaces. 
+                                                                    """The geometric area, A_{geom} , is the interfacial area, determined on the assumption that the interface is truly flat (2-dimensional) and calculated using the geometric data of the involved surfaces.
 
 The real (true) area, A_{real}, takes into account non-idealities of the interface (roughness, porosity, etc.) and can be measured by a variety of electrochemical methods. The electroactive area is the area calculated from experiments with model electroactive species and may be different from the real surface area in cases where not all of the surface is electrochemically active or accessible."""@en ;
                                                        skos:prefLabel "ElectrodeSurfaceArea"@en .
@@ -1458,9 +1458,9 @@ G° or ΔrG , written as a reduction with respect to that of the standard hydrog
                                                        rdfs:subClassOf :electrochemistry_2a2f59b7_aa16_40aa_9c8b_0de8a2720456 ;
                                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Faradaic current measured in a solution containing two electroactive substances, A and B, that exceeds the sum of the faradaic currents that would be obtained for A and B separately under the same experimental conditions."@en ;
                                                        rdfs:comment "I_{cat}"@en ,
-                                                                    """In either of the two following situations, the current increase is termed a catalytic current: 
+                                                                    """In either of the two following situations, the current increase is termed a catalytic current:
 
-(i) The scheme below generates a catalytic or regenerative current: 
+(i) The scheme below generates a catalytic or regenerative current:
 
 B±e→ B′
 B' + A → B

--- a/isq_bigmap.ttl
+++ b/isq_bigmap.ttl
@@ -7,7 +7,7 @@
 @base <http://emmo.info/emmo/temp/isq_bigmap> .
 
 <http://emmo.info/emmo/disciplines/isq_bigmap> rdf:type owl:Ontology ;
-                                                owl:versionIRI <http://emmo.info/emmo/1.0.0-beta4/temp/isq_big_map> .
+                                                owl:versionIRI <http://emmo.info/emmo/1.0.0-beta4/temp/isq_bigmap> .
 
 #################################################################
 #    Annotation properties


### PR DESCRIPTION
The catalog file is now updated and EMMOntoPy is able to load the whole ontology without issue. So this doesn't completely close the issue, but at least it is a start. I think it would be useful to merge this variant at least first to see how it cascades down on the github workflows using this repository.