### PR TITLE
Import EMMO consistent with how it is imported in CHAMEO

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="https://w3id.org/emmo/domain/chemicalsubstance/0.2.0/chemicalsubstance" uri="https://raw.githubusercontent.com/emmo-repo/domain-chemical-substance/main/chemicalsubstance.ttl"/>
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/domain/chameo/1.0.0-beta3/chameo.ttl" uri="https://raw.githubusercontent.com/emmo-repo/domain-characterisation-methodology/main/chameo.ttl"/>
-    <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-        <uri name="https://w3id.org/emmo/domain/electrochemistry/0.8.0-alpha/electrochemistry" uri="./electrochemistry.ttl"/>
-        <uri name="https://w3id.org/emmo/domain/electrochemistry/0.8.0-alpha/electrochemicalquantities" uri="./electrochemicalquantities.ttl"/>
-    </group>
+  <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
+    <uri name="https://w3id.org/emmo/domain/chemicalsubstance/0.2.0/chemicalsubstance" uri="https://raw.githubusercontent.com/emmo-repo/domain-chemical-substance/main/chemicalsubstance.ttl"/>
+    <uri name="http://emmo.info/emmo/domain/chameo/1.0.0-beta3/chameo" uri="https://raw.githubusercontent.com/emmo-repo/domain-characterisation-methodology/main/chameo.ttl"/>
+    <uri name="https://w3id.org/emmo/domain/electrochemistry/0.8.0-alpha/electrochemistry" uri="./electrochemistry.ttl"/>
+    <uri name="https://w3id.org/emmo/domain/electrochemistry/0.8.0-alpha/electrochemicalquantities" uri="./electrochemicalquantities.ttl"/>
+  </group>
 </catalog>

--- a/electrochemicalquantities.ttl
+++ b/electrochemicalquantities.ttl
@@ -12,7 +12,7 @@
 
 <https://w3id.org/emmo/domain/electrochemistry/electrochemicalquantities> rdf:type owl:Ontology ;
                                                                owl:versionIRI <https://w3id.org/emmo/domain/electrochemistry/0.8.0-alpha/electrochemicalquantities> ;
-                                                               owl:imports <http://emmo.info/emmo/1.0.0-beta5> ;
+                                                               owl:imports <http://emmo.info/emmo/1.0.0-beta5/disciplines/isq> ;
                                                                dcterms:abstract """This electrochemical quantities ontology is a domain of the Elementary Multiperspective Materials Ontology (EMMO). It is a specialized framework designed to represent and organize knowledge about electrochemical quantities. It is designed to integrate with the electrochemistry domain ontology or other ontologies from the EMMO ecosystem. The main focus of this ontology is to provide machine-readable descriptions of common electrochemical quantities, linking both to the larger descriptions of physical quantities in EMMO as well as other sources of information like the IEC, QUDT, Wikidata, etc. It should be used to support linked data generation in the electrochemistry domain."""@en ;
                                                                dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
                                                                owl:versionInfo "0.8.0-alpha" .

--- a/electrochemistry.ttl
+++ b/electrochemistry.ttl
@@ -13,7 +13,7 @@
 
 <https://w3id.org/emmo/domain/electrochemistry/electrochemistry> rdf:type owl:Ontology ;
                                                                   owl:versionIRI <https://w3id.org/emmo/domain/electrochemistry/0.8.0-alpha/electrochemistry> ;
-                                                                  owl:imports <http://emmo.info/emmo/domain/chameo/1.0.0-beta3/chameo.ttl> ,
+                                                                  owl:imports <http://emmo.info/emmo/domain/chameo/1.0.0-beta3/chameo> ,
                                                                               <https://w3id.org/emmo/domain/chemicalsubstance/0.2.0/chemicalsubstance> ,
                                                                               <https://w3id.org/emmo/domain/electrochemistry/0.8.0-alpha/electrochemicalquantities> ;
                                                                   dcterms:abstract "The Electrochemistry Domain Ontology, a specialized domain within the Elementary Multiperspective Materials Ontology (EMMO), encompasses essential terms and relationships for electrochemical systems, materials, methods, and data. Its primary objective is to enable the creation of linked and FAIR (Findable, Accessible, Interoperable, and Reusable) data, thereby fostering advancements in research and innovation within the realm of electrochemistry. This ontology serves as a foundational resource for harmonizing electrochemical knowledge representation, enhancing data interoperability, and accelerating progress in electrochemical research and development."@en ;


### PR DESCRIPTION
Import EMMO consistent with how it is imported in CHAMEO. 

The electrochemicalquantities module seems to only need isq (and its dependencies) from EMMO.

