### PR TITLE
Use emmontopy for docs

### DIFF
--- a/.github/scripts/ontology_toolkit.py
+++ b/.github/scripts/ontology_toolkit.py
@@ -327,22 +327,23 @@ def entities_to_rst(entities: list[dict]) -> str:
 
 
         # Add callouts (admonitions) below the table
-        callout_mapping = {
-            "Tip": "tip",
-            "Caution": "caution",
-            "Important": "important",
-            "Note": "note",
-            "Danger": "danger",
-            "Warning": "warning",
-            "Error": "error",
-            "Admonition": "admonition"
-        }
+        #callout_mapping = {
+        #    "Tip": "tip",
+        #    "Caution": "caution",
+        #    "Important": "important",
+        #    "Note": "note",
+        #    "Danger": "danger",
+        #    "Warning": "warning",
+        #    "Error": "error",
+        #    "Admonition": "admonition"
+        #}
 
         callout_rst = ""
-        for callout, admonition in callout_mapping.items():
+        #for callout, admonition in callout_mapping.items():
+        for callout in callout_keys:
             callout_value = item.get(callout, "").strip()
             if callout_value and callout_value.lower() != "none":
-                callout_rst += f".. {admonition}::\n\n"
+                callout_rst += f".. {callout}::\n\n"
                 for line in callout_value.splitlines():
                     callout_rst += f"   {line}\n"
                 callout_rst += "\n"

--- a/.github/scripts/ontology_toolkit.py
+++ b/.github/scripts/ontology_toolkit.py
@@ -10,6 +10,8 @@ from urllib.request import pathname2url
 from rdflib import Graph
 import logging
 from owlrl import DeductiveClosure, OWLRL_Semantics
+from ontopy.ontology import Ontology
+import owlready2
 
 def print_ttl_files():
     config = load_ontology_config()
@@ -109,21 +111,29 @@ def create_jsonld_context_file():
 ########## RST Documentation Generation (ttl_to_rst logic) ##########
 
 def load_ttl_from_file(filepath):
-    g = rdflib.Graph()
-    g.parse(filepath, format="turtle")
-    return g
+    from ontopy import get_ontology
+    onto = get_ontology(filepath).load()
+    return onto
+
+def _extract_all_annotations(value_list):
+    '''Help Function to extract both the text of a locstr and just str
+    from annotations. For now only choosing english. Note that this is a bit of a hack since not all annotations
+    are implemented as a locstr as they should. Perhaps this should be fixed in 
+    emmocheck instead?'''
+    result = []
+    for elem in value_list:
+        # For plain strings: only include if its type is exactly str.
+        if type(elem) is str:
+            result.append(elem)
+        # For locstr strings: include if its language is English.
+        elif hasattr(elem, "lang") and elem.lang == "en":
+            result.append(elem)
+    return result
 
 
-def extract_terms_info_sparql(g: Graph) -> list:
+def extract_terms_info_sparql(onto: Ontology) -> list:
     """Extracts terms from the TTL graph using SPARQL, including parent, subclass, and restriction links."""
     text_entities = []
-
-    PREFIXES = """
-        PREFIX emmo: <https://w3id.org/emmo#>
-        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        PREFIX owl: <http://www.w3.org/2002/07/owl#>
-        """
 
     list_entity_types = [
         "IRI", "prefLabel", "Elucidation", "Alternative Label(s)",
@@ -133,89 +143,35 @@ def extract_terms_info_sparql(g: Graph) -> list:
         "Warning", "Admonition"
     ]
 
-    query = PREFIXES + """
-        SELECT ?iri ?prefLabel ?elucidation 
-               (GROUP_CONCAT(?altLabel; SEPARATOR=", ") AS ?altLabels) 
-               ?iecref ?iupacref ?wikipediaref ?wikidataref 
-               ?comment ?tip ?caution ?important ?note ?danger
-               ?error ?warning ?admonition
-        WHERE {
-            ?iri skos:prefLabel ?prefLabel.
+    config = load_ontology_config()
 
-            OPTIONAL { ?iri emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ?elucidation . }
-            OPTIONAL { ?iri skos:altLabel ?altLabel . }
-            OPTIONAL { ?iri emmo:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f ?iecref . }
-            OPTIONAL { ?iri emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 ?iupacref . }
-            OPTIONAL { ?iri emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d ?wikipediaref . }
-            OPTIONAL { ?iri emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 ?wikidataref . }
-            OPTIONAL { ?iri rdfs:comment ?comment . }
+    for entity in onto.get_entities(imported=False):
+        hit_dict = {'IRI': entity.iri}
+        # This is a bit of a hack, need to have a better way to be sure that we only 
+        # consider terms defined in the current ontology (and not just referenes here)
+        if not entity.iri.split('#')[0] == config["ontology_prefix"].rstrip('#/'):
+            continue
+ 
 
-            OPTIONAL { ?iri emmo:EMMO_b6730304_cabc_4104_b415_14218466445c ?caution . }
-            OPTIONAL { ?iri emmo:EMMO_5f7abc2a_5b50_41c3_8def_c8ba7c3b083e ?tip . }
-            OPTIONAL { ?iri emmo:EMMO_4c8480cf_56de_41da_8699_f12a9033313a ?important . }
-            OPTIONAL { ?iri skos:note ?note . }
-            OPTIONAL { ?iri emmo:EMMO_95317324_4b53_4665_a087_82c3a2a0540b ?danger . }
-            OPTIONAL { ?iri emmo:EMMO_32214c66_8bce_40f5_b22d_5059f6cf571b ?error . }
-            OPTIONAL { ?iri emmo:EMMO_0fa6566e_500f_4d24_baa9_b2b22c9a0b72 ?warning . }
-            OPTIONAL { ?iri emmo:EMMO_709ee08d_76b1_4fee_be22_925412ac313b ?admonition . }
+        #if not (isinstance(entity, owlready2.ThingClass) or isinstance(entity, owlready2.PropertyClass)):
+        #    continue
+
+        annotations = entity.get_annotations()
+        annotations_en = {
+                key: '; '.join(_extract_all_annotations(item))
+            for key, item in annotations.items()
         }
-        GROUP BY ?iri ?prefLabel ?elucidation ?caution ?tip ?important ?note ?danger ?error ?warning ?admonition
-        """
 
-    qres = g.query(query)
+        hit_dict.update(annotations_en)
 
-    for hit in qres:
-        hit_dict = {entity_type: str(entity) for entity_type, entity in zip(list_entity_types, hit)}
-
-        # Fetch direct parents (rdfs:subClassOf)
-        parents = []
-        parent_query = PREFIXES + """
-            SELECT ?parent ?parentLabel WHERE {
-                <%s> rdfs:subClassOf ?parent .
-                ?parent skos:prefLabel ?parentLabel .
-            }
-        """ % hit_dict['IRI']
-        for row in g.query(parent_query):
-            parent_iri, parent_label = row
-            parents.append((str(parent_iri), str(parent_label)))
+        parents = [ent for ent in entity.is_a if (isinstance(ent, owlready2.ThingClass) or isinstance(ent, owlready2.PropertyClass))]
         hit_dict["Parent Classes"] = parents
 
         # Fetch direct subclasses
-        subclasses = []
-        subclass_query = PREFIXES + """
-            SELECT ?subclass ?subclassLabel WHERE {
-                ?subclass rdfs:subClassOf <%s> .
-                ?subclass skos:prefLabel ?subclassLabel .
-            }
-        """ % hit_dict['IRI']
-        for row in g.query(subclass_query):
-            subclass_iri, subclass_label = row
-            subclasses.append((str(subclass_iri), str(subclass_label)))
-        hit_dict["Subclasses"] = subclasses
+        subclasses = list(entity.subclasses())
 
         # Fetch OWL Restrictions (object property + someValuesFrom)
-        restrictions = []
-        restriction_query = PREFIXES + """
-            SELECT ?prop ?propLabel ?target ?targetLabel WHERE {
-                <%s> rdfs:subClassOf [
-                    rdf:type owl:Restriction ;
-                    owl:onProperty ?prop ;
-                    owl:someValuesFrom ?target
-                ] .
-                ?prop skos:prefLabel ?propLabel .
-                ?target skos:prefLabel ?targetLabel .
-            }
-        """ % hit_dict['IRI']
-
-        for row in g.query(restriction_query):
-            prop_iri, prop_label, target_iri, target_label = map(str, row)
-            restrictions.append({
-                "property_iri": prop_iri,
-                "property_label": prop_label,
-                "target_iri": target_iri,
-                "target_label": target_label,
-            })
-
+        restrictions = [restriction for restriction in entity.is_a if isinstance(restriction, owlready2.Restriction)]
         hit_dict["Restrictions"] = restrictions
 
         text_entities.append(hit_dict)
@@ -271,7 +227,6 @@ def entities_to_rst(entities: list[dict]) -> str:
 
         rst += ".. raw:: html\n\n"
         rst += f"   <div id=\"{iri_suffix}\"></div>\n\n"
-        
         rst += f"{item['prefLabel']}\n"
         rst += "-" * len(item['prefLabel']) + "\n\n"
         rst += f"IRI: {item['IRI']}\n\n"
@@ -288,18 +243,26 @@ def entities_to_rst(entities: list[dict]) -> str:
             rst += "  <tr>\n"
             rst += f"    <td class=\"element-table-key\"><span class=\"element-table-key\">{key}</span></td>\n"
 
+            #print(value)
             if value.startswith("http"):
                 value = f"<a href='{value}'>{value}</a>"
 
             rst += f"    <td class=\"element-table-value\">{value}</td>\n"
             rst += "  </tr>\n"
-
         # Add parent classes section
         if item.get("Parent Classes"):
             rst += "  <tr>\n"
             rst += "    <td class=\"element-table-key\"><span class=\"element-table-key\">Parent Classes</span></td>\n"
             rst += "    <td class=\"element-table-value\">"
-            parent_links = [f"<a href='#{iri.split('#')[-1]}'>{label}</a>" for iri, label in item["Parent Classes"]]
+
+            parent_links = []
+            for parent in item["Parent Classes"]:
+                try:
+                    parent_links.append(f"<a href='#{parent.iri.split('#')[-1]}'>{parent.prefLabel.get_lang('en')[0]}</a>")
+                except:
+                    parent_links.append(f"<a href='#{parent.iri.split('#')[-1]}'>{parent}</a>")
+
+            
             rst += ", ".join(parent_links)
             rst += "</td>\n"
             rst += "  </tr>\n"
@@ -319,15 +282,18 @@ def entities_to_rst(entities: list[dict]) -> str:
             # Group restrictions by property_label for cleaner table (optional, but nice)
             grouped_restrictions = {}
             for restriction in item["Restrictions"]:
-                prop_label = restriction['property_label']
-                target_link = f"<a href='#{restriction['target_iri'].split('#')[-1]}'>{restriction['target_label']}</a>"
-                if prop_label not in grouped_restrictions:
-                    grouped_restrictions[prop_label] = []
-                grouped_restrictions[prop_label].append(target_link)
+                try:
+                    target_link = f"<a href='#{restriction.value.iri.split('#')[-1]}'>{restriction.value}</a>"
+                except AttributeError:
+                    target_link = f"<a href='#{restriction.value}'>{restriction.value}</a>"
+
+                if restriction.property not in grouped_restrictions:
+                    grouped_restrictions[restriction.property] = []
+                grouped_restrictions[restriction.property].append(target_link)
 
             for prop_label, target_links in grouped_restrictions.items():
                 rst += "  <tr>\n"
-                rst += f"    <td class=\"element-table-key\"><span class=\"element-table-key\">{prop_label}</span></td>\n"
+                rst += f"    <td class=\"element-table-key\"><span class=\"element-table-key\">{restriction.property}</span></td>\n"
                 rst += "    <td class=\"element-table-value\">"
                 rst += ", ".join(target_links)
                 rst += "</td>\n"
@@ -374,8 +340,8 @@ def generate_rst_documentation():
     for module in config["ttl_files"]:
         filepath = module["path"]
         if os.path.isfile(filepath):
-            g = load_ttl_from_file(filepath)
-            entities = extract_terms_info_sparql(g)
+            onto = load_ttl_from_file(filepath)
+            entities = extract_terms_info_sparql(onto)
             rst_content += f"\n{module['section_title']}\n{'=' * len(module['section_title'])}\n\n"
             rst_content += entities_to_rst(entities)
 
@@ -479,6 +445,9 @@ def run_reasoner_check():
         sys.exit(1)
 
 ########## Main Entry Point ##########
+
+#def run_ontodoc():
+
 
 def main():
     config = load_ontology_config()

--- a/.github/scripts/ontology_toolkit.py
+++ b/.github/scripts/ontology_toolkit.py
@@ -214,6 +214,8 @@ def render_rst_abstract(onto) -> str:
 def entities_to_rst(entities: list[dict]) -> str:
     """Converts extracted ontology terms into an RST format."""
     rst = ""
+    
+    IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".svg")
 
     callout_keys = {"tip", "caution", "important", "note", "danger", "warning", "error", "admonition"}
     ls = []
@@ -250,11 +252,21 @@ def entities_to_rst(entities: list[dict]) -> str:
             for val in value:
                 rst += "  <tr>\n"
                 rst += f"    <td class=\"element-table-key\"><span class=\"element-table-key\">{key}</span></td>\n"
-
                 if val.startswith("http"):
-                    val = f"<a href='{val}'>{val}</a>"
+                    if val.lower().endswith(tuple(IMAGE_EXTENSIONS)):
+                        val = (
+                            f'<a href="{val}">'
+                            f'<img src="{val}" alt="{val}" '
+                            f'style="max-width:400px; max-height:300px;"/>'
+                            f'</a>'
+                        )
+                        
+                    else:
+                        val = f"<a href='{val}'>{val}</a>"
+
                 rst += f"    <td class=\"element-table-value\">{val}</td>\n"
                 rst += "  </tr>\n"
+            
         
         
         def _get_links(item, key):
@@ -324,19 +336,6 @@ def entities_to_rst(entities: list[dict]) -> str:
                 rst += "</td>\n"
                 rst += "  </tr>\n"
         rst += "  </table>\n\n"
-
-
-        # Add callouts (admonitions) below the table
-        #callout_mapping = {
-        #    "Tip": "tip",
-        #    "Caution": "caution",
-        #    "Important": "important",
-        #    "Note": "note",
-        #    "Danger": "danger",
-        #    "Warning": "warning",
-        #    "Error": "error",
-        #    "Admonition": "admonition"
-        #}
 
         callout_rst = ""
         #for callout, admonition in callout_mapping.items():

--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,8 @@ ontology_prefix: "https://w3id.org/emmo/domain/electrochemistry#"
 ontology_description: "The ontology for electrochemical systems."
 
 ttl_files:
+  - section_title: "Electrochemistry Domain Ontology (ECHO)"
+    path: "electrochemistry.ttl"
   - section_title: "Electrochemistry Reference"
     path: "reference/electrochemistry-reference.ttl"
   - section_title: "Electrochemistry Quantities"
@@ -15,8 +17,6 @@ ttl_files:
     path: "modules/electrochemistry-manufacturing.ttl"
   - section_title: "Electrochemistry Testing"
     path: "modules/electrochemistry-testing.ttl"
-  - section_title: "Main Ontology"
-    path: "electrochemistry.ttl"
 
 output:
   inferred_ttl: "electrochemistry-inferred.ttl"

--- a/reference/electrochemistry-quantities.ttl
+++ b/reference/electrochemistry-quantities.ttl
@@ -666,8 +666,7 @@ emmo:EMMO_e6e7277a_1d40_4be5_a3a9_afd3da53d937 rdfs:subClassOf :electrochemistry
                                                                          owl:someValuesFrom emmo:EMMO_02e894c3_b793_4197_b120_3442e08f58d1
                                                                        ] ;
                                                        rdfs:comment "Buck and Lindner suggest a slope of 0.6 mV min-1 ."@en ,
-                                                                    """Previously defined response times t95 (corresponding to the 95% change of the potential span) and t* (to 1 mV from the steady value) require prior knowledge of steady-state E values that may not be available. These descriptive quantities underestimate practical response times of ion-selective electrodes in clinical applications where the total span may be narrower than 10 mV. The response time expressed in terms of ΔE/Δt (i.e., rate of cell potential variation with time) seems to be the best choice among non-ideal options. It can be related to t95
-and t* through mathematical models, provided that the long-time potential- determining processes are identified."""@en ;
+                                                                    """Previously defined response times t95 (corresponding to the 95% change of the potential span) and t* (to 1 mV from the steady value) require prior knowledge of steady-state E values that may not be available. These descriptive quantities underestimate practical response times of ion-selective electrodes in clinical applications where the total span may be narrower than 10 mV. The response time expressed in terms of ΔE/Δt (i.e., rate of cell potential variation with time) seems to be the best choice among non-ideal options. It can be related to t95 and t* through mathematical models, provided that the long-time potential- determining processes are identified."""@en ;
                                                        skos:prefLabel "ResponseTimeAtAnISE"@en ;
                                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Duration between the time when an ion-selective electrode and an external reference electrode (the two completing the ion-selective electrode cell) are brought into contact with a sample solution (or the time at which the activity of the ion of interest in solution is changed) and the first time at which the slope of the cell potential vs. time plot (ΔE/Δt) becomes equal to a limiting value selected on the basis of the experimental conditions and/or requirements concerning accuracy."@en .
 
@@ -1365,9 +1364,7 @@ and t* through mathematical models, provided that the long-time potential- deter
                                                        rdfs:subClassOf :electrochemistry_05cf26ef_782a_4f66_a196_7004dd973f8e ,
                                                                        :electrochemistry_aecc6094_c6a5_4a36_a825_8a497a2ae112 ;
                                                        rdfs:comment "A"@en ,
-                                                                    """The geometric area, A_{geom} , is the interfacial area, determined on the assumption that the interface is truly flat (2-dimensional) and calculated using the geometric data of the involved surfaces.
-
-The real (true) area, A_{real}, takes into account non-idealities of the interface (roughness, porosity, etc.) and can be measured by a variety of electrochemical methods. The electroactive area is the area calculated from experiments with model electroactive species and may be different from the real surface area in cases where not all of the surface is electrochemically active or accessible."""@en ;
+                                                                    """The geometric area, A_{geom} , is the interfacial area, determined on the assumption that the interface is truly flat (2-dimensional) and calculated using the geometric data of the involved surfaces. The real (true) area, A_{real}, takes into account non-idealities of the interface (roughness, porosity, etc.) and can be measured by a variety of electrochemical methods. The electroactive area is the area calculated from experiments with model electroactive species and may be different from the real surface area in cases where not all of the surface is electrochemically active or accessible."""@en ;
                                                        skos:prefLabel "ElectrodeSurfaceArea"@en ;
                                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "area of electrode - solution interface."@en .
 
@@ -3178,16 +3175,7 @@ The real (true) area, A_{real}, takes into account non-idealities of the interfa
 :electrochemistry_c55bcb85_b7b8_4e67_8a78_9a42fe25b6cf rdf:type owl:Class ;
                                                        rdfs:subClassOf :electrochemistry_2a2f59b7_aa16_40aa_9c8b_0de8a2720456 ;
                                                        rdfs:comment "I_{cat}"@en ,
-                                                                    """In either of the two following situations, the current increase is termed a catalytic current:
-
-(i) The scheme below generates a catalytic or regenerative current:
-
-B±e→ B′
-B' + A → B
-
-(ii) The presence at the electrode-solution interface of a substance, which may be added or generated by an electrochemical reaction, decreases the overpotential for the electrochemical reaction of B.
-
-In either case, the magnitude of the catalytic current depends on the applied potential. If the current observed with a mixture of A and B is lower than the sum of the separate currents, the term non-additive current should be used."""@en ;
+                                                                    """In either of the two following situations, the current increase is termed a catalytic current: (i) The scheme below generates a catalytic or regenerative current: B±e→ B′, B' + A → B (ii) The presence at the electrode-solution interface of a substance, which may be added or generated by an electrochemical reaction, decreases the overpotential for the electrochemical reaction of B. In either case, the magnitude of the catalytic current depends on the applied potential. If the current observed with a mixture of A and B is lower than the sum of the separate currents, the term non-additive current should be used."""@en ;
                                                        skos:prefLabel "CatalyticCurrent"@en ;
                                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "faradaic current measured in a solution containing two electroactive substances, A and B, that exceeds the sum of the faradaic currents that would be obtained for A and B separately under the same experimental conditions"@en ;
                                                        emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1351/goldbook.C00889"@en .

--- a/reference/electrochemistry-reference.ttl
+++ b/reference/electrochemistry-reference.ttl
@@ -4750,8 +4750,7 @@ Cl2, Hg | Hg2SO4, and Hg | HgO, can be used as reference electrodes in aqueous s
                                                        rdfs:subClassOf :electrochemistry_0acd0fc2_1048_4604_8e90_bf4e84bd87df ;
                                                        skos:prefLabel "ConductivityCell"@en ;
                                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "an electrochemical cell for conductivity measurements"@en ;
-                                                       emmo:EMMO_c7b62dd7_063a_4c2a_8504_42f7264ba83f """Formed, in theory, by two 1 cm2 reversible electrodes spaced 1 cm apart, providing a uniform distribution of electrical field. In practice, however, a number
-of other configurations are used."""@en .
+                                                       emmo:EMMO_c7b62dd7_063a_4c2a_8504_42f7264ba83f """Formed, in theory, by two 1 cm2 reversible electrodes spaced 1 cm apart, providing a uniform distribution of electrical field. In practice, however, a number of other configurations are used."""@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource :electrochemistry_b525a629_a679_464f_bc5b_b49d2fc82686 ;

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -27,7 +27,7 @@ typing_extensions==4.7.1
 zipp==3.15.0
 
 # Ontology handling and linked data tools
-EMMOntoPy>=0.4.0,<1
+EMMOntoPy>=0.8.0,<0.8.1
 rdflib
 owlrl
 PyYAML


### PR DESCRIPTION
This allows for more accurate way of caputring all annotations and restrictions.

Things that need to be fixed:

- [x] Add abstract from the ontology automatically
- [x] Correct rendering of restrictions. Checkout rendering functionality in ontopy.utils
- [x] Comments should be added as separate lines
- [x] Parent Classes, use subclassOf as label
- [x] Render admonitions as done in the previous version
- [x] Add illustrations (e.f. ElectrochemicalCell)
- [x] Ordering of annotations. 'altLabel, elucidation, rdfs:comment, skos:example, rdfs:seeAlso, rdfs:isDefinedBy, anyextrannotations, restrictions, subclassOf, subclasses'
- [x] subClasses have fallen out
- [ ] Eventually: The code should be a separate module in ontopy
- [x] Fix order so that main ontology is first (i.e. the loaded ontology, then imported)
- [x] Update dependencies:  emmontopy

Points for discussion:
- [x] Capitalise or not? Now it is note done, except for with the admonitions.
- [ ] 